### PR TITLE
Extended main blog redesign to all pages

### DIFF
--- a/resources/views/about/index.blade.php
+++ b/resources/views/about/index.blade.php
@@ -1,8 +1,32 @@
 @extends('layouts.wrapper', ['title' => 'About author'])
 
 @section('content')
-    <div class="container-lg mt-4">
-        <h1>About author</h1>
-        <p>Foo text</p>
-    </div>
+    <div class="container-lg mt-5">
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="p-3 p-md-3 rounded text-body-emphasis bg-body-secondary">
+                    <div class="card-body p-5">
+                        <!-- Author Image -->
+                        <div class="text-center mb-4">
+                            <i class="bi bi-person-circle fs-2 text-muted"></i>
+                        </div>
+
+                        <!-- Header -->
+                        <div class="text-center mb-5">
+                            <h2 style="font-family: 'Playfair Display', serif;">About the Author</h1>
+                                <p class="lead text-muted">Get to know the person behind the posts</p>
+                        </div>
+
+                        <!-- Author Bio -->
+                        <p class="text-muted text-center mb-4">
+                            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
+                            labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                            laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+                            voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat
+                            non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        </div>
 @endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,73 +1,94 @@
 @extends('layouts.wrapper-auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Авторизация') }}</div>
-
-                <div class="card-body">
-                    <form method="POST" action="{{ route('login') }}">
-                        @csrf
-
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Электронная почта') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
-
-                                @error('email')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Пароль') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
-
-                                @error('password')
-                                    <span class="invalid-feedback" role="alert">
-                                        <strong>{{ $message }}</strong>
-                                    </span>
-                                @enderror
-                            </div>
-                        </div>
-
-                        <div class="row mb-3">
-                            <div class="col-md-6 offset-md-4">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
-
-                                    <label class="form-check-label" for="remember">
-                                        {{ __('Запомнить меня') }}
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="row mb-0">
-                            <div class="col-md-8 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Войти') }}
-                                </button>
-
-                                @if (Route::has('password.request'))
-                                    <a class="btn btn-link" href="{{ route('password.request') }}">
-                                        {{ __('Забыли пароль?') }}
+    <div class="justify-content">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-5">
+                <div class="card shadow-lg border-0 rounded-4">
+                    <div class="card-header bg-transparent text-center py-4">
+                        <h4 class="mb-3 text-center">
+                            </i> {{ __('Login') }}
+                        </h4>
+                        <div class="text-center">
+                            @guest
+                                @if (Route::has('register'))
+                                    <a class="btn btn-sm gap-2 rounded-pill px-4 align-items-center" href="{{ route('register') }}">
+                                        {{ __('Don\'t have an account? Sign Up') }} <i class="bi bi-person-plus"></i>
                                     </a>
                                 @endif
-                            </div>
+                            @endguest
                         </div>
+                    </div>
+
+                    <div class="card-body p-4 p-lg-5">
+                        <form method="POST" action="{{ route('login') }}">
+                            @csrf
+
+                            <!-- Email Field -->
+                            <div class="mb-4">
+                                <label for="email" class="form-label text-muted small mb-1">{{ __('Email') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-envelope text-muted"></i>
+                                    </span>
+                                    <input id="email" type="email"
+                                        class="form-control border-start-0 @error('email') is-invalid @enderror"
+                                        name="email" value="{{ old('email') }}" required autocomplete="email" autofocus
+                                        placeholder="example@domain.com">
+                                </div>
+                                @error('email')
+                                    <span class="invalid-feedback d-block" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                @enderror
+                            </div>
+
+                            <!-- Password Field -->
+                            <div class="mb-4">
+                                <label for="password" class="form-label text-muted small mb-1">{{ __('Password') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-lock text-muted"></i>
+                                    </span>
+                                    <input id="password" type="password"
+                                        class="form-control border-start-0 @error('password') is-invalid @enderror"
+                                        name="password" required autocomplete="current-password" placeholder="••••••••">
+                                </div>
+                                @error('password')
+                                    <span class="invalid-feedback d-block" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                @enderror
+                            </div>
+
+                            <!-- Remember Me Checkbox -->
+                            <div class="mb-4 form-check">
+                                <input class="form-check-input" type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
+                                <label class="form-check-label text-muted small" for="remember">
+                                    {{ __('Remember me') }}
+                                </label>
+                            </div>
+
+                            <!-- Submit Button -->
+                            <div class="d-grid mb-4">
+                                <button type="submit" class="btn btn-sm btn-primary rounded-pill py-2 fw-bold">
+                                    <i class="bi bi-box-arrow-in-right me-2"></i> {{ __('Login') }}
+                                </button>
+                            </div>
+
+                            <!-- Forgot Password Link -->
+                            @if (Route::has('password.request'))
+                                <div class="text-center">
+                                    <a class="text-decoration-none text-muted small" href="{{ route('password.request') }}">
+                                        {{ __('Forgot password?') }}
+                                    </a>
+                                </div>
+                            @endif
+                    </div>
                     </form>
                 </div>
             </div>
         </div>
     </div>
-</div>
+    </div>
 @endsection

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,77 +1,108 @@
 @extends('layouts.wrapper-auth')
 
 @section('content')
-<div class="container">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-header">{{ __('Регистрация') }}</div>
+    <div class="justify-content">
+        <div class="row justify-content-center">
+            <div class="col-md-6 col-lg-5">
+                <div class="card shadow-lg border-0 rounded-4">
+                    <div class="card-header bg-transparent text-center py-4">
+                        <h4 class="mb-3 text-center">
+                            {{ __('Sign up') }}
+                        </h4>
+                        <div class="text-center">
+                            @guest
+                                @if (Route::has('login'))
+                                    <a class="btn btn-sm gap-2 rounded-pill px-4 align-items-center" href="{{ route('login') }}">
+                                        {{ __('Do you have an account? Login') }} <i class="bi bi-box-arrow-in-right"></i>
+                                    </a>
+                                @endif
+                            @endguest
+                        </div>
+                    </div>
 
-                <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
-                        @csrf
+                    <div class="card-body p-4 p-lg-5">
+                        <form method="POST" action="{{ route('register') }}">
+                            @csrf
 
-                        <div class="row mb-3">
-                            <label for="name" class="col-md-4 col-form-label text-md-end">{{ __('Имя') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
-
+                            <!-- Name Field -->
+                            <div class="mb-4">
+                                <label for="name" class="form-label text-muted small mb-1">{{ __('Name') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-person text-muted"></i>
+                                    </span>
+                                    <input id="name" type="text"
+                                        class="form-control border-start-0 @error('name') is-invalid @enderror" name="name"
+                                        value="{{ old('name') }}" required autocomplete="name" autofocus
+                                        placeholder="Your name">
+                                </div>
                                 @error('name')
-                                    <span class="invalid-feedback" role="alert">
+                                    <span class="invalid-feedback d-block" role="alert">
                                         <strong>{{ $message }}</strong>
                                     </span>
                                 @enderror
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Электронная почта') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
-
+                            <!-- Email Field -->
+                            <div class="mb-4">
+                                <label for="email" class="form-label text-muted small mb-1">{{ __('Email') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-envelope text-muted"></i>
+                                    </span>
+                                    <input id="email" type="email"
+                                        class="form-control border-start-0 @error('email') is-invalid @enderror"
+                                        name="email" value="{{ old('email') }}" required autocomplete="email"
+                                        placeholder="example@domain.com">
+                                </div>
                                 @error('email')
-                                    <span class="invalid-feedback" role="alert">
+                                    <span class="invalid-feedback d-block" role="alert">
                                         <strong>{{ $message }}</strong>
                                     </span>
                                 @enderror
                             </div>
-                        </div>
 
-                        <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Пароль') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
-
+                            <!-- Password Field -->
+                            <div class="mb-4">
+                                <label for="password" class="form-label text-muted small mb-1">{{ __('Password') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-lock text-muted"></i>
+                                    </span>
+                                    <input id="password" type="password"
+                                        class="form-control border-start-0 @error('password') is-invalid @enderror"
+                                        name="password" required autocomplete="new-password" placeholder="••••••••">
+                                </div>
                                 @error('password')
-                                    <span class="invalid-feedback" role="alert">
+                                    <span class="invalid-feedback d-block" role="alert">
                                         <strong>{{ $message }}</strong>
                                     </span>
                                 @enderror
                             </div>
-                        </div>
-
-                        <div class="row mb-3">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-end">{{ __('Подтвердите пароль') }}</label>
-
-                            <div class="col-md-6">
-                                <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
+                            <!-- Confirm Password Field -->
+                            <div class="mb-4">
+                                <label for="password-confirm"
+                                    class="form-label text-muted small mb-1">{{ __('Confirm password') }}</label>
+                                <div class="input-group">
+                                    <span class="input-group-text bg-light border-end-0">
+                                        <i class="bi bi-lock text-muted"></i>
+                                    </span>
+                                    <input id="password-confirm" type="password" class="form-control border-start-0"
+                                        name="password_confirmation" required autocomplete="new-password"
+                                        placeholder="••••••••">
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="row mb-0">
-                            <div class="col-md-6 offset-md-4">
-                                <button type="submit" class="btn btn-primary">
-                                    {{ __('Регистрация') }}
+                            <!-- Submit Button -->
+                            <div class="d-grid mb-4">
+                                <button type="submit" class="btn btn-sm btn-primary rounded-pill py-2 fw-bold">
+                                    <i class="bi bi-person-plus me-2"></i> {{ __('Sign in') }}
                                 </button>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 @endsection

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -1,11 +1,45 @@
 @extends('layouts.wrapper', ['title' => 'Contacts'])
 
 @section('content')
-    <div class="container-lg mt-4">
-        <h1>Contacts</h1>
-        <p>Email: mail@gmail.com</p>
-        <p><a href="#">Telegram</a></p>
-        <p><a href="#">VK</a></p>
-        <p><a href="#">Whatsapp</a></p>
+    <div class="container-lg mt-5">
+
+        <!-- Contact Info Card -->
+        <div class="row justify-content-center">
+            <div class="col-lg-8">
+                <div class="p-3 p-md-3 rounded text-body-emphasis bg-body-secondary">
+                    <div class="card-body p-5">
+                        <!-- Header -->
+                        <div class="text-center mb-5">
+                            <h2 style="font-family: 'Playfair Display', serif;">Contacts</h2>
+                        </div>
+
+                        <!-- Email -->
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <i class="bi bi-envelope fs-4 text-muted"></i>
+                            <p class="mb-0"><a href="mailto:mail@gmail.com" class="text-decoration-none">mail@gmail.com</a>
+                            </p>
+                        </div>
+
+                        <!-- Telegram -->
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <i class="bi bi-telegram fs-4 text-muted"></i>
+                            <p class="mb-0"><a href="#" class="text-decoration-none">Telegram</a></p>
+                        </div>
+
+                        <!-- VK -->
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <i class="bi bi-people fs-4 text-muted"></i>
+                            <p class="mb-0"><a href="#" class="text-decoration-none">VK</a></p>
+                        </div>
+
+                        <!-- WhatsApp -->
+                        <div class="d-flex align-items-center gap-3 mb-4">
+                            <i class="bi bi-whatsapp fs-4 text-muted"></i>
+                            <p class="mb-0"><a href="#" class="text-decoration-none">WhatsApp</a></p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 @endsection

--- a/resources/views/layouts/wrapper-auth.blade.php
+++ b/resources/views/layouts/wrapper-auth.blade.php
@@ -1,76 +1,72 @@
 <!doctype html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-
     <meta name="csrf-token" content="{{ csrf_token() }}">
-
     <title>{{ config('app.name', 'Laravel') }}</title>
-
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Playfair&#43;Display:700,900&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ asset('assets/css/app.css') }}">
 </head>
+
 <body>
-
-        <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
-            <div class="container">
-                <a class="navbar-brand" href="{{ url('/') }}">
-
-                </a>
-                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-                    <span class="navbar-toggler-icon"></span>
-                </button>
-
-                <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                    <!-- Left Side Of Navbar -->
-                    <ul class="navbar-nav me-auto">
-
-                    </ul>
-
-                    <!-- Right Side Of Navbar -->
-                    <ul class="navbar-nav ms-auto">
-                        <!-- Authentication Links -->
-                        @guest
-                            @if (Route::has('login'))
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('login') }}">{{ __('Вход') }}</a>
-                                </li>
-                            @endif
-
-                            @if (Route::has('register'))
-                                <li class="nav-item">
-                                    <a class="nav-link" href="{{ route('register') }}">{{ __('Регистрация') }}</a>
-                                </li>
-                            @endif
-                        @else
-                            <li class="nav-item dropdown">
-                                <a id="navbarDropdown" class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
-                                    {{ Auth::user()->name }}
-                                </a>
-
-                                <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
-                                    <a class="dropdown-item" href="{{ route('logout') }}"
-                                       onclick="event.preventDefault();
-                                                     document.getElementById('logout-form').submit();">
-                                        {{ __('Выйти') }}
+    <div class="container">
+        <header class="border-bottom lh-1 py-3">
+            <div class="row flex-nowrap justify-content-between align-items-center">
+                <div class="col-4"></div>
+                <div class="col-4 text-center">
+                    <a class="blog-header-logo text-body-emphasis text-decoration-none" href="{{ route('main.index') }}"
+                        style="font-family: 'Playfair Display', serif; font-weight: 700; font-size: 1.95rem;">
+                        My Personal Blog
+                    </a>
+                </div>
+                <div class="col-4 d-flex justify-content-end align-items-center">
+                    @auth
+                        <div class="dropdown">
+                            <a class="btn btn-sm btn-outline-primary dropdown-toggle gap-2 rounded-pill px-4 d-flex align-items-center"
+                                href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                <i class="bi bi-person-circle"></i>
+                                {{ Auth::user()->name }}
+                            </a>
+                            <ul class="dropdown-menu dropdown-menu-end shadow-lg rounded-3">
+                                <li>
+                                    <a class="dropdown-item d-flex align-items-center gap-2"
+                                        href="{{ route('personal.main.index') }}">
+                                        <i class="bi bi-person"></i> Profile
                                     </a>
-
-                                    <form id="logout-form" action="{{ route('logout') }}" method="POST" class="d-none">
+                                </li>
+                                <li>
+                                    <hr class="dropdown-divider">
+                                </li>
+                                <li>
+                                    <form method="POST" action="{{ route('logout') }}">
                                         @csrf
+                                        <button type="submit" class="dropdown-item d-flex align-items-center gap-2">
+                                            <i class="bi bi-box-arrow-right"></i> Logout
+                                        </button>
                                     </form>
-                                </div>
-                            </li>
-                        @endguest
-                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    @else
+                        <a class="btn btn-sm bg-primary text-white gap-2 rounded-pill px-4 d-flex align-items-center"
+                            href="{{ route('login') }}">
+                            <i class="bi bi-box-arrow-in-right"></i> Log in
+                        </a>
+                    @endauth
                 </div>
             </div>
-        </nav>
+        </header>
+    </div>
 
-        <main class="py-4">
-            @yield('content')
-        </main>
+    <main class="py-4">
+        @yield('content')
+    </main>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
+
 </html>

--- a/resources/views/layouts/wrapper-personal.blade.php
+++ b/resources/views/layouts/wrapper-personal.blade.php
@@ -1,57 +1,35 @@
 <!DOCTYPE html>
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>{{ $title ?? 'Page Title' }}</title>
 
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
-    <link rel="stylesheet" href="{{ asset('assets/css/app.css') }}">
+<head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <title>{{ $title ?? 'Page Title' }}</title>
+
+        <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+                integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+                crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+        <link rel="stylesheet" href="{{ asset('assets/css/app.css') }}">
 </head>
+
 <body>
 
-@include('layouts.wrapper._navbar')
+        @include('layouts.wrapper._navbar')
 
-<!-- Navbar -->
-<nav class="main-header navbar navbar-expand navbar-white navbar-light">
-    <!-- Left navbar links -->
-    <ul class="navbar-nav">
-        <li class="nav-item">
-            <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
-        </li>
-    </ul>
-    <ul class="navbar-nav ml-auto">
-        <li>
-            Пользователь:  <span class="text-success">{{ auth()->user()->name}}</span>
-        </li>
-    </ul>
-    <!-- Right navbar links -->
-    <ul class="navbar-nav ml-auto">
-        <li>
-            <form action="{{ route('logout') }}" method="post">
-                @csrf
-                <input type="submit" class="btn btn-outline-primary" value="Выйти">
-            </form>
-        </li>
-    </ul>
-</nav>
-<!-- /.navbar -->
+        @yield('content')
 
-@include('layouts.wrapper-personal.sidebar')
+        @include('layouts.wrapper._footer')
 
-@yield('content')
-
-@include('layouts.wrapper._footer')
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-        crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"
-        integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r"
-        crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+                integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+                crossorigin="anonymous"></script>
+        <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.11.8/dist/umd/popper.min.js"
+                integrity="sha384-I7E8VVD/ismYTF4hNIPjVp/Zjvgyol6VFvRkX/vR+Vc4jQkC+hVqc2pM8ODewa9r"
+                crossorigin="anonymous"></script>
 
 </body>
+
 </html>

--- a/resources/views/personal/comment/edit.blade.php
+++ b/resources/views/personal/comment/edit.blade.php
@@ -1,38 +1,41 @@
 @extends('layouts.wrapper-personal', ['title' => 'My personal blog'])
 
 @section('content')
-    <div class="content-wrapper">
-        <!-- Content Header (Page header) -->
-        <div class="content-header">
-            <div class="container-fluid">
-                <div class="row mb-2">
-                    <div class="col-sm-6">
-                        <h1 class="m-0">Редактирование комментария</h1>
-                    </div><!-- /.col -->
-                </div><!-- /.row -->
-            </div><!-- /.container-fluid -->
+    <div class="container">
+        <!-- Header -->
+        <div class="d-flex justify-content-between align-items-center pb-1 mt-5 mb-5">
+            <h3 style="font-family: 'Playfair Display', serif;">
+                Edit comment
+            </h3>
         </div>
-        <!-- /.content-header -->
 
-        <!-- Main content -->
-        <section class="content">
-            <div class="container-fluid">
-                <row>
-                    <div class="w-25">
-                        <form method="post" action="{{ route('personal.comment.update', $comment->id) }}">
-                            @csrf
-                            @method('patch')
-                            <div class="form-group">
-                                <textarea class="form-control" name="message" cols="10" rows="10">{{ $comment->message }}</textarea>
-                                @error('message')
-                                <div class="text-danger">Это поле необходимо заполнить</div>
-                                @enderror
+        <!-- Card -->
+        <div class="card shadow-sm rounded-lg">
+            <div class="card-body">
+                <form method="post" action="{{ route('personal.comment.update', $comment->id) }}">
+                    @csrf
+                    @method('patch')
+
+                    <!-- Comment Textarea -->
+                    <div class="mb-4">
+                        <label for="message" class="form-label">Comment</label>
+                        <textarea class="form-control @error('message') is-invalid @enderror" name="message" id="message"
+                            rows="5">{{ $comment->message }}</textarea>
+                        @error('message')
+                            <div class="invalid-feedback">
+                                This field is required.
                             </div>
-                            <input type="submit" class="btn btn-primary" value="Обновить">
-                        </form>
+                        @enderror
                     </div>
-                </row>
+
+                    <!-- Submit Button -->
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn btn-sm btn-primary rounded-pill px-4">
+                            <i class="bi bi-save me-2"></i> Update
+                        </button>
+                    </div>
+                </form>
             </div>
-        </section>
+        </div>
     </div>
 @endsection

--- a/resources/views/personal/comment/index.blade.php
+++ b/resources/views/personal/comment/index.blade.php
@@ -1,71 +1,59 @@
 @extends('layouts.wrapper-personal', ['title' => 'My personal blog'])
 
 @section('content')
-    <div class="content-wrapper">
-        <!-- Content Header (Page header) -->
-        <div class="content-header">
-            <div class="container-fluid">
-                <div class="row mb-2">
-                    <div class="col-sm-6">
-                        <h1 class="m-0">Комментарии</h1>
-                    </div><!-- /.col -->
-                </div><!-- /.row -->
-            </div><!-- /.container-fluid -->
+    <div class="container">
+        <!-- Header -->
+        <div class="d-flex justify-content-between align-items-center pb-1 mt-5 mb-5">
+            <h3 style="font-family: 'Playfair Display', serif;">
+                Comments
+            </h3>
         </div>
-        <!-- /.content-header -->
 
-        <!-- Main content -->
-        <section class="content">
-            <div class="container-fluid">
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-6">
-                        <div class="card">
-                            <!-- /.card-header -->
-                            <div class="card-body table-responsive p-0">
-                                <table class="table table-hover text-nowrap">
-                                    <thead>
-                                    <tr>
-                                        <th>ID</th>
-                                        <th>Комментарий</th>
-                                        <th>Название поста</th>
-                                        <th>Редактировать</th>
-                                        <th>Удалить</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    @foreach($comments as $comment)
-                                        <tr>
-                                            <td>{{ $comment->id }}</td>
-                                            <td>{{ $comment->message }}</td>
-                                            <td>{{ $comment->post->title }}</td>
-                                            <td><a href="{{ route('personal.comment.edit', $comment->id) }}" class="text-success"><i class="fas fa-edit"></i></a></td>
-                                            <td>
-                                                <form action="{{ route('personal.comment.delete', $comment->id)}}"
-                                                      method="post">
-                                                    @csrf
-                                                    @method('delete')
-                                                    <button type="submit" class="border-0 bg-transparent">
-                                                        <i class="far fa-trash-alt text-danger"></i>
-                                                    </button>
-                                                </form>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!-- /.card-body -->
-                        </div>
-                        <!-- /.card -->
-                    </div>
-                </div>
-                <!-- /.row -->
-                <!-- /.content -->
+        <!-- Card -->
+        <div class="card shadow-sm rounded-lg">
+            <!-- /.card-header -->
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead class="bg-light">
+                        <tr>
+                            <th class="py-4">ID</th>
+                            <th class="py-4">Comment</th>
+                            <th class="py-4">Post title</th>
+                            <th class="py-4">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($comments as $comment)
+                            <tr class="hover-effect">
+                                <td class="align-middle py-4">{{ $comment->id }}</td>
+                                <td class="align-middle py-4">{{ $comment->message }}</td>
+                                <td class="align-middle py-4">{{ $comment->post->title }}</td>
+                                <td class="align-middle py-4">
+                                    <div class="d-flex gap-2">
+                                        <!-- Edit Button -->
+                                        <a href="{{ route('personal.comment.edit', $comment->id) }}"
+                                            class="btn btn-sm btn-outline-success gap-2 rounded-pill px-4 d-flex align-items-center">
+                                            <i class="bi bi-pencil"></i> Edit
+                                        </a>
+
+                                        <!-- Delete Button -->
+                                        <form action="{{ route('personal.comment.delete', $comment->id) }}" method="post">
+                                            @csrf
+                                            @method('delete')
+                                            <button type="submit"
+                                                class="btn btn-sm btn-outline-danger rounded-pill d-flex align-items-center gap-2 px-4">
+                                                <i class="bi bi-trash"></i> Delete
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
             </div>
-        </section>
+            <!-- /.card-body -->
+        </div>
+        <!-- /.card -->
     </div>
-
-
-
 @endsection

--- a/resources/views/personal/liked/index.blade.php
+++ b/resources/views/personal/liked/index.blade.php
@@ -1,68 +1,59 @@
 @extends('layouts.wrapper-personal', ['title' => 'My personal blog'])
 
 @section('content')
-    <div class="content-wrapper">
-        <!-- Content Header (Page header) -->
-        <div class="content-header">
-            <div class="container-fluid">
-                <div class="row mb-2">
-                    <div class="col-sm-6">
-                        <h1 class="m-0">Мне нравится</h1>
-                    </div><!-- /.col -->
-                </div><!-- /.row -->
-            </div><!-- /.container-fluid -->
+    <div class="container">
+        <!-- Header -->
+        <div class="d-flex justify-content-between align-items-center pb-1 mt-5 mb-5">
+            <h3 style="font-family: 'Playfair Display', serif;">
+                Liked posts
+            </h3>
         </div>
-        <!-- /.content-header -->
 
-        <!-- Main content -->
-        <section class="content">
-            <div class="container-fluid">
-                <!-- /.row -->
-                <div class="row">
-                    <div class="col-6">
-                        <div class="card">
-                            <!-- /.card-header -->
-                            <div class="card-body table-responsive p-0">
-                                <table class="table table-hover text-nowrap">
-                                    <thead>
-                                    <tr>
-                                        <th>ID</th>
-                                        <th>Название поста</th>
-                                        <th>Просмотр поста</th>
-                                        <th>Удалить</th>
-                                    </tr>
-                                    </thead>
-                                    <tbody>
-                                    @foreach($posts as $post)
-                                        <tr>
-                                            <td>{{ $post->id }}</td>
-                                            <td>{{ $post->title }}</td>
-                                            <td><a href="{{ route('post.show', $post->id) }}"><i class="far fa-eye"></i></a></td>
-                                            <td>
-                                                <form action="{{ route('personal.liked.delete', $post->id) }}" method="post">
-                                                    @csrf
-                                                    @method('delete')
-                                                    <button type="submit" class="border-0 bg-transparent">
-                                                        <i class="far fa-trash-alt text-danger"></i>
-                                                    </button>
-                                                </form>
-                                            </td>
-                                        </tr>
-                                    @endforeach
-                                    </tbody>
-                                </table>
-                            </div>
-                            <!-- /.card-body -->
-                        </div>
-                        <!-- /.card -->
-                    </div>
-                </div>
-                <!-- /.row -->
-                <!-- /.content -->
+        <!-- Card -->
+        <div class="card shadow-sm rounded-lg">
+
+            <!-- /.card-header -->
+            <div class="card-body">
+                <table class="table table-hover">
+                    <thead class="bg-light">
+                        <tr>
+                            <th class="py-4">ID</th>
+                            <th class="py-4">Post title</th>
+                            <th class="py-4">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($posts as $post)
+                            <tr class="hover-effect">
+                                <td class="align-middle py-4">{{ $post->id }}</td>
+                                <td class="align-middle py-4">{{ $post->title }}</td>
+                                <td class="align-middle py-4">
+                                    <div class="d-flex gap-2">
+                                        <!-- View Button -->
+                                        <a href="{{ route('post.show', $post->id) }}"
+                                            class="btn btn-sm btn-outline-primary gap-2 rounded-pill px-4 d-flex align-items-center">
+                                            <i class="bi bi-eye"></i> View
+                                        </a>
+
+                                        <!-- Unliked Button -->
+                                        <form action="{{ route('personal.liked.delete', $post->id) }}" method="post">
+                                            @csrf
+                                            @method('delete')
+                                            <button type="submit"
+                                                class="btn btn-sm btn-outline-danger rounded-pill d-flex align-items-center gap-2 px-4">
+                                                <i class="bi bi-heart"></i> Unliked
+                                            </button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+
+                </table>
             </div>
-        </section>
+            <!-- /.card-body -->
+        </div>
+        <!-- /.card -->
     </div>
-
-
-
 @endsection

--- a/resources/views/personal/main/index.blade.php
+++ b/resources/views/personal/main/index.blade.php
@@ -1,59 +1,67 @@
-@extends('layouts.wrapper-personal', ['title' => 'My personal blog'])
+@extends('layouts.wrapper-personal', ['title' => 'My Personal Blog'])
 
 @section('content')
-
-    <div class="content-wrapper">
-        <!-- Content Header (Page header) -->
-        <div class="content-header">
-            <div class="container-fluid">
-                <div class="row mb-2">
-                    <div class="col-sm-6">
-                        <h1 class="m-0">Главное меню</h1>
-                    </div><!-- /.col -->
-                </div><!-- /.row -->
-            </div><!-- /.container-fluid -->
+    <div class="container-lg mt-5">
+        <!-- Header -->
+        <div class="text-center mb-5">
+            <h2 style="font-family: 'Playfair Display', serif;">Profile</h2>
         </div>
-        <!-- /.content-header -->
 
-        <!-- Main content -->
-        <section class="content">
-            <div class="container-fluid">
-                <!-- Small boxes (Stat box) -->
-                <div class="row">
-                    <div class="col-lg-3 col-6">
-                        <!-- small box -->
-                        <div class="small-box bg-info">
-                            <div class="inner">
-                                <h3>{{ $data['countLiked'] }}</h3>
-
-                                <p>Мне нравится</p>
+        <!-- Stats Cards -->
+        <div class="row g-4 justify-content-center">
+            <!-- Liked Posts -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card border-0 shadow h-100 bg-secondary bg-opacity-10">
+                    <div class="card-body p-4 d-flex flex-column">
+                        <div class="d-flex align-items-center justify-content-between mb-3">
+                            <h4 class="card-title mb-0" style="font-family: 'Playfair Display', serif;">
+                                Liked posts
+                            </h4>
+                            <div class="icon bg-primary rounded-circle d-flex align-items-center justify-content-center"
+                                style="width: 50px; height: 50px;">
+                                <i class="bi bi-heart-fill fs-5 text-white"></i>
                             </div>
-                            <div class="icon">
-                                <i class="fas fa-heart"></i>
-                            </div>
-                            <a href="{{ route('personal.liked.index') }}" class="small-box-footer">Подробнее <i class="fas fa-arrow-circle-right"></i></a>
                         </div>
+                        <h4 class="mb-4">{{ $data['countLiked'] }}</h4>
+                        <a href="{{ route('personal.liked.index') }}"
+                            class="btn btn-outline-primary rounded-pill align-self-start">
+                            Read more <i class="bi bi-arrow-right ms-2"></i>
+                        </a>
                     </div>
-                    <!-- ./col -->
-                    <div class="col-lg-3 col-6">
-                        <!-- small box -->
-                        <div class="small-box bg-success">
-                            <div class="inner">
-                                <h3>{{ $data['countComments'] }}</h3>
-
-                                <p>Мои комментарии</p>
-                            </div>
-                            <div class="icon">
-                                <i class="far fa-comment"></i>
-                            </div>
-                            <a href="{{ route('personal.comment.index') }}" class="small-box-footer">Подробнее <i class="fas fa-arrow-circle-right"></i></a>
-                        </div>
-                    </div>
-                    <!-- ./col -->
                 </div>
-            </div><!-- /.container-fluid -->
-        </section>
-        <!-- /.content -->
-    </div>
+            </div>
 
+            <!-- My Comments -->
+            <div class="col-md-6 col-lg-4">
+                <div class="card border-0 shadow h-100 bg-secondary bg-opacity-10">
+                    <div class="card-body p-4 d-flex flex-column">
+                        <div class="d-flex align-items-center justify-content-between mb-3">
+                            <h4 class="card-title mb-0" style="font-family: 'Playfair Display', serif;">
+                                Comments
+                            </h4>
+                            <div class="icon bg-success rounded-circle d-flex align-items-center justify-content-center"
+                                style="width: 50px; height: 50px;">
+                                <i class="bi bi-chat-dots-fill fs-5 text-white"></i>
+                            </div>
+                        </div>
+                        <h4 class="mb-4">{{ $data['countComments'] }}</h4>
+                        <a href="{{ route('personal.comment.index') }}"
+                            class="btn btn-outline-success rounded-pill align-self-start">
+                            Read more <i class="bi bi-arrow-right ms-2"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection
+
+<style>
+    .icon {
+        transition: background-color 0.3s ease;
+    }
+
+    .icon:hover {
+        background-color: rgba(0, 0, 0, 0.1) !important;
+    }
+</style>

--- a/resources/views/post/show.blade.php
+++ b/resources/views/post/show.blade.php
@@ -1,114 +1,147 @@
 @extends('layouts.wrapper', ['title' => $post->title])
 
 @section('content')
-    <div class="container-lg">
-        <div class="row">
-            <div class="col-lg-9 mx-auto">
-                <h1>{{ $post->title }}</h1>
-                <p>
-                    {{ $date->day }} {{ $date->translatedFormat('F') }} {{ $date->year }} {{ $date->format('H:i') }}
-                    • {{ $post->comments->count() }} comments
-                </p>
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-lg-9 mx-auto">
-                <img src="{{ $post->main_image }}" alt="featured image">
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-lg-9 mx-auto">
-                {!! $post->content !!}
-            </div>
-        </div>
-
-        <div class="row">
-            <div class="col-lg-9 mx-auto">
-                @foreach($post->tags as $tag)
-                    <span class="badge bg-info text-wrap ml-1">{{ $tag->title }}</span>
-                @endforeach
-            </div>
-        </div>
-
-        {{-- TODO Fix sections below --}}
-        <div class="row">
-            <div class="col-lg-9 mx-auto">
-                <section class="py-5 ml-2">
-                    @auth()
-                        <form action="{{ route('post.likes.store', $post->id) }}" method="post">
-                            @csrf
-                            <span>{{ $post->liked_users_count }}</span>
-                            <button type="submit" class="border-0 bg-transparent">
-                                @if(auth()->user()->likedPosts->contains($post->id))
-                                    <i class="fas fa-heart" style="color: #f64343;"></i>
-                                @else
-                                    <i class="far fa-heart"></i>
-                                @endif
-                            </button>
-                        </form>
-                    @endauth
-                    @guest()
-                        <div>
-                            <span>{{ $post->liked_users_count }}</span>
-                            <i class="far fa-heart"></i>
-                        </div>
-                    @endguest
-                </section>
-                @if($relatedPosts->count() > 0)
-                    <section class="related-posts">
-                        <h2 class="section-title mb-4" data-aos="fade-up">Related posts</h2>
-                        <div class="row">
-                            @foreach($relatedPosts as $relatedPost)
-                                <div class="col-md-4" data-aos="fade-right" data-aos-delay="100">
-                                    <img src="{{ $relatedPost->main_image }}" alt="related post"
-                                         class="post-thumbnail d-flex h-50">
-                                    <p class="post-category">TODO Show categories</p>
-                                    <a href="{{ route('post.show', $relatedPost->id) }}"><h5
-                                            class="post-title">{{ $relatedPost->title }}</h5></a>
-                                </div>
-                            @endforeach
-                        </div>
-                    </section>
-                @endif
-                <section class="comment-list mb-5 fw-bold">
-                    <h2 class="section-list mb-5" data-aos="fade-up">Comments ({{ $post->comments->count() }}
-                        )</h2>
-                    @foreach($post->comments as $comment)
-                        <div class="comment-text mb-3">
-                            <span class="username">
-                                <div>
-                                    <b>{{ $comment->user->name }}</b>
-                                </div>
-                              <span class="text-muted float-right">{{ $comment->dataAsCarbon->diffForHumans() }}</span>
-                            </span><!-- /.username -->
-                            {{ $comment->message }}
-                        </div>
-                    @endforeach
-                </section>
-                @auth()
-                    <section class="comment-section">
-                        <h2 class="section-title mb-5" data-aos="fade-up">Добавить комментарий</h2>
-                        <form action="{{ route('post.comments.store', $post->id) }}" method="post">
-                            @csrf
-                            <div class="row">
-                                <div class="form-group col-12" data-aos="fade-up">
-                                    <label for="comment" class="sr-only">Comment</label>
-                                    <textarea name="message" id="comment" class="form-control"
-                                              placeholder="Напишите комментарий" rows="10"></textarea>
-                                </div>
-                            </div>
-                            <div class="row">
-                                <div class="col-12" data-aos="fade-up">
-                                    <input type="submit" value="Отправить" class="btn btn-warning">
-                                </div>
-                            </div>
-                        </form>
-                    </section>
-                @endauth
+<div class="container">
+    <!-- Post Header -->
+    <div class="row">
+        <div class="col-lg-10 mx-auto mt-4">
+            <h2 style="font-family: 'Playfair Display', serif;">
+                {{ $post->title }}
+            </h2>
+            <div class="d-flex align-items-center gap-3 bg-light p-3 rounded mb-5 mt-4">
+                <i class="bi bi-calendar"></i>
+                <span class="text-muted">
+                    {{ $date->day }} {{ $date->translatedFormat('F') }} {{ $date->year }} • {{ $date->format('H:i') }}
+                </span>
+                <i class="bi bi-chat"></i>
+                <span class="text-muted">{{ $post->comments->count() }} comments</span>
             </div>
         </div>
     </div>
 
+    <!-- Featured Image -->
+    <div class="row">
+        <div class="col-lg-10 mx-auto">
+            <img src="{{ $post->main_image }}" alt="featured image" class="img-fluid w-100 rounded mb-5">
+        </div>
+    </div>
+
+    <!-- Post Content -->
+    <div class="row">
+        <div class="col-lg-10 mx-auto">
+            {!! $post->content !!}
+        </div>
+    </div>
+
+    <!-- Tags -->
+    <div class="row mt-5">
+        <div class="col-lg-10 mx-auto">
+            @foreach($post->tags as $tag)
+                <span class="badge bg-info text-wrap mb-2">{{ $tag->title }}</span>
+            @endforeach
+        </div>
+    </div>
+
+   <!-- Like Section -->
+    <div class="row mt-5">
+        <div class="col-lg-10 mx-auto">
+            <section class="py-5">
+                <div class="d-flex align-items-center gap-3">
+                    @auth()
+                        <form action="{{ route('post.likes.store', $post->id) }}" method="post">
+                            @csrf
+                            <button type="submit" class="btn btn-outline-danger rounded-pill d-flex align-items-center gap-2">
+                                @if(auth()->user()->likedPosts->contains($post->id))
+                                    <i class="bi bi-heart-fill"></i>
+                                @else
+                                    <i class="bi bi-heart"></i>
+                                @endif
+                                <span>{{ $post->liked_users_count }}</span>
+                            </button>
+                        </form>
+                    @endauth
+                    @guest()
+                        <div class="d-flex align-items-center gap-2">
+                            <i class="bi bi-heart"></i>
+                            <span>{{ $post->liked_users_count }}</span>
+                        </div>
+                    @endguest
+
+                    <span class="text-muted">
+                        {{ $post->liked_users_count == 1 ? 'person likes' : 'people like' }} this post.
+                    </span>
+                </div>
+            </section>
+        </div>
+    </div>
+
+    <!-- Related Posts -->
+    @if($relatedPosts->count() > 0)
+        <div class="row mt-5">
+            <div class="col-lg-10 mx-auto">
+                <section class="related-posts">
+                    <h2 class="section-title mb-4">Related posts</h2>
+                    <div class="row">
+                        @foreach($relatedPosts as $relatedPost)
+                            <div class="col-md-4 mb-4">
+                                <img src="{{ $relatedPost->main_image }}" alt="related post" class="img-fluid rounded mb-2">
+                                <a href="{{ route('post.show', $relatedPost->id) }}">
+                                    <h5 class="post-title">{{ $relatedPost->title }}</h5>
+                                </a>
+                            </div>
+                        @endforeach
+                    </div>
+                </section>
+            </div>
+        </div>
+    @endif
+
+    <!-- Comments Section -->
+    <div class="row mt-5">
+        <div class="col-lg-10 mx-auto">
+            <section class="comment-list mb-5">
+                <h2 class="section-title mb-4">Comments ({{ $post->comments->count() }})</h2>
+                @foreach($post->comments as $comment)
+                    <div class="comment-text bg-light p-4 rounded mb-4">
+                        <div class="d-flex align-items-center gap-3 mb-3">
+                            <!-- Ícone de usuário -->
+                            <i class="bi bi-person-circle fs-4 text-muted"></i>
+                            <div>
+                                <span class="username fw-bold">{{ $comment->user->name }}</span>
+                                <span class="text-muted ms-2">
+                                    <i class="bi bi-clock"></i> {{ $comment->created_at ? $comment->created_at->diffForHumans() : 'Just now' }}
+                                </span>
+                            </div>
+                        </div>
+                        <p class="mb-0">{{ $comment->message }}</p>
+                    </div>
+                @endforeach
+            </section>
+        </div>
+    </div>
+
+    <!-- Add Comment Section -->
+    @auth()
+    <div class="row mt-5">
+        <div class="col-lg-9 mx-auto">
+            <section class="comment-section mb-5">
+                <h2 class="section-title mb-4">Add a comment</h2>
+                <form action="{{ route('post.comments.store', $post->id) }}" method="post">
+                    @csrf
+                    <div class="form-group mb-4">
+                        <label for="comment" class="form-label text-muted small mb-2">Your comment</label>
+                        <textarea name="message" id="comment" class="form-control shadow-sm" rows="5"
+                                placeholder="Write your comment here..." style="border-radius: 10px;"></textarea>
+                    </div>
+                    <div class="d-flex justify-content-end">
+                        <button type="submit" class="btn btn-sm btn-primary rounded-pill px-4 py-2 d-flex align-items-center gap-2">
+                            <i class="bi bi-send"></i> Send
+                        </button>
+                    </div>
+                </form>
+            </section>
+        </div>
+    </div>
+    @endauth
+</div>
 @endsection


### PR DESCRIPTION
This pull request applies the main design from the blog's page (#427) to the following pages:

### Redesigned Pages
**Public Pages**  
- [X] About author  
- [X] Contact  

**Authenticated User Pages**  
- [X] Login page  
- [X] Sign Up page  
- [ ] Password Reset page  
- [X] Profile page (liked posts and comments)
- [X] Posts page

Additionally, I translated the content from Russian to English on these pages. Below are a few examples:

![image](https://github.com/user-attachments/assets/ab25472a-be94-4913-8110-634e97044897)
![Captura de tela de 2025-02-16 17-31-46](https://github.com/user-attachments/assets/c72c0709-3d4e-44b4-bf59-18a06c73a932)
![Captura de tela de 2025-02-16 17-31-20](https://github.com/user-attachments/assets/fb869725-50aa-4764-837b-57263c91daa8)
![Captura de tela de 2025-02-16 17-31-10](https://github.com/user-attachments/assets/a205ba80-433d-4b5a-87ba-f219606ad782)